### PR TITLE
add app description to manifest to support p2p distribution

### DIFF
--- a/app/AndroidManifest.xml
+++ b/app/AndroidManifest.xml
@@ -43,6 +43,7 @@
         android:configChanges="orientation|keyboardHidden|screenSize|locale"
         android:icon="@drawable/ic_launcher"
         android:label="@string/app_name"
+        android:description="@string/app_description"
         android:largeHeap="true"
         android:supportsRtl="true"
         android:theme="@style/Theme.storymakerstyle" >

--- a/app/res/values/strings.xml
+++ b/app/res/values/strings.xml
@@ -2,6 +2,7 @@
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
 
     <string name="app_name">StoryMaker</string>
+    <string name="app_description">Creating great stories is now easier than ever with StoryMaker. Our unique templates, overlays, and lessons guide you through the entire creative process. StoryMaker lets you edit your content right on your mobile, making it even easier to finish your story. Once you've finished, StoryMaker lets you publish your story to all of your favorite platforms.</string>
     <string name="app_id" translatable="false">509922855786064</string>
     <string name="title_projects">Stories</string>
     <string name="title_lessons">Lessons</string>


### PR DESCRIPTION
This allows other methods of distributing APKs to also include the description text, like the FDroid local repo swapping.
