### PR TITLE
make jenkins-build.sh easy to run on any machine

### DIFF
--- a/jenkins-build.sh
+++ b/jenkins-build.sh
@@ -1,9 +1,24 @@
 #!/bin/sh
 
+set -e
+set -x
+
+if [ -z $WORKSPACE ]; then
+    export WORKSPACE=`pwd`
+fi
+
+if [ -z $ANDROID_HOME ]; then
+    if [ -e ~/.android/bashrc ]; then
+        . ~/.android/bashrc
+    else
+        echo "ANDROID_HOME must be set!"
+        exit
+    fi
+fi
+
+git submodule sync --recursive
 git submodule foreach --recursive "git submodule sync"
 git submodule update --init --recursive
-
-. ~/.android/bashrc
 
 ./setup-ant.sh
 cd $WORKSPACE/external/android-ffmpeg-java/external/android-ffmpeg/


### PR DESCRIPTION
Make it easy to test this script on any machine.  After turning on "Delete workspace before building" in Jenkins, this builds on my job.
